### PR TITLE
fine grained exceptions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,18 +3,20 @@
 The class Augeas provides bindings to augeas [http://augeas.net] library.
 
 == Usage: Setting Data
-    Augeas::open do |aug|
-      aug.set("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT", "YES")
-      unless aug.save
-        raise IOError, "Failed to save changes"
-      end
+  Augeas::create do |aug|
+    aug.set("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT", "YES")
+    unless aug.save
+      raise IOError, "Failed to save changes"
     end
+  end
 
 == Usage: Accessing Data
-    firstboot = Augeas::open { |aug| aug.get("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT") }
+    firstboot = Augeas::create {
+      |aug| aug.get("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT") }
+
 
 == Usage: Removing Data
-    Augeas::open do |aug|
+    Augeas::create do |aug|
       aug.rm("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT")
       unless aug.save
         raise IOError, "Failed to save changes"
@@ -23,12 +25,64 @@ The class Augeas provides bindings to augeas [http://augeas.net] library.
 
 == Usage: Minimal Setup with a Custom Root
 
-By passing +NO_MODL_AUTOLOAD+, no files are read on startup; that allows
-setting up a custom transform.
+By passing using the +:no_modl_autoload+ flag, no files are read on
+startup; that allows setting up a custom transform.
 
-  Augeas::open("/var/tmp/augeas-root", "/usr/local/share/mylenses",
-                Augeas::NO_MODL_AUTOLOAD) do |aug|
+  Augeas::create(:root => "/var/tmp/augeas-root",
+                 :loadpath => "/usr/local/share/mylenses",
+                 :no_modl_autoload => true) do |aug|
     aug.transform(:lens => "Aliases.lns", :incl => "/etc/aliases")
     aug.load
     aug.get("/files/etc/aliases/*[name = 'postmaster']/value")
   end
+
+      
+== Deprecation Warning
+
+The Augeas API has been heavily rewritten in order to better support
+errors. While the old functionality is still available unchanged if you
+instantiate the Augeas object with <tt>Augeas::open</tt>, it is highly
+preferred that you use the new API.
+
+To use the new API, just use <tt>Augeas::create</tt> instead of
+<tt>Augeas::open</tt>. This is the documentation for the
+<tt>Augeas::create</tt> method.
+
+Create a new Augeas instance and return it.
+
+Use <tt>:root</tt> as the filesystem root. If <tt>:root</tt> is
+<tt>nil</tt>, use the value of the environment variable
+<tt>AUGEAS_ROOT</tt>. If that doesn't exist either, use "/".
+
+<tt>:loadpath</tt> is a colon-spearated list of directories that modules
+should be searched in. This is in addition to the standard load path and
+the directories in <tt>AUGEAS_LENS_LIB</tt>.
+
+The following flags can be specified in a hash. They all default to
+false and can be enabled by setting them to true
+
+<tt>:type_check</tt> - typecheck lenses (since it can be very expensive
+it is not done by default)
+
+<tt>:no_stdinc</tt> - do not use the builtin load path for modules
+
+<tt>:no_load</tt> - do not load the tree during the initialization phase
+
+<tt>:no_modl_autoload</tt> - do not load the tree during the
+initialization phase
+
+<tt>:enable_span</tt> - track the span in the input nodes
+
+<tt>:save_mode</tt> can be one of <tt>:backup</tt>, <tt>:newfile</tt>,
+<tt>:noop</tt> as explained below.
+
+  :noop - make save a no-op process, just record what would have changed
+
+  :backup - keep the original file with an .augsave extension
+
+  :newfile - save changes into a file with an .augnew extension and do
+  not overwrite the original file.
+
+When a block is given, the Augeas instance is passed as the only
+argument into the block and closed when the block exits.  With no block,
+the Augeas instance is returned.

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -244,11 +244,23 @@ VALUE augeas_match_old(VALUE s, VALUE p) {
 
 /*
  * call-seq:
- *       save() -> boolean
+ *       save() -> int
  *
  * Write all pending changes to disk
  */
 VALUE augeas_save(VALUE s) {
+    augeas *aug = aug_handle(s);
+    int callValue = aug_save(aug);
+    return INT2FIX(callValue);
+}
+
+/*
+ * call-seq:
+ *       save() -> boolean
+ *
+ * Write all pending changes to disk
+ */
+VALUE augeas_save_old(VALUE s) {
     augeas *aug = aug_handle(s);
     int callValue = aug_save(aug) ;
     VALUE returnValue ;
@@ -488,7 +500,7 @@ void Init__augeas() {
     rb_define_method(c_augeas_old, "mv", augeas_mv, 2);
     rb_define_method(c_augeas_old, "rm", augeas_rm, 1);
     rb_define_method(c_augeas_old, "match", augeas_match_old, 1);
-    rb_define_method(c_augeas_old, "save", augeas_save, 0);
+    rb_define_method(c_augeas_old, "save", augeas_save_old, 0);
     rb_define_method(c_augeas_old, "load", augeas_load, 0);
     rb_define_method(c_augeas_old, "set_internal", augeas_set_old, 2);
     rb_define_method(c_augeas_old, "setm", augeas_setm, 3);

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -275,11 +275,23 @@ VALUE augeas_save_old(VALUE s) {
 
 /*
  * call-seq:
- *       load() -> boolean
+ *       load() -> int
  *
  * Load files from disk according to the transforms under +/augeas/load+
  */
 VALUE augeas_load(VALUE s) {
+    augeas *aug = aug_handle(s);
+    int callValue = aug_load(aug);
+    return INT2FIX(callValue);
+}
+
+/*
+ * call-seq:
+ *       load() -> boolean
+ *
+ * Load files from disk according to the transforms under +/augeas/load+
+ */
+VALUE augeas_load_old(VALUE s) {
     augeas *aug = aug_handle(s);
     int callValue = aug_load(aug);
     VALUE returnValue ;
@@ -501,7 +513,7 @@ void Init__augeas() {
     rb_define_method(c_augeas_old, "rm", augeas_rm, 1);
     rb_define_method(c_augeas_old, "match", augeas_match_old, 1);
     rb_define_method(c_augeas_old, "save", augeas_save_old, 0);
-    rb_define_method(c_augeas_old, "load", augeas_load, 0);
+    rb_define_method(c_augeas_old, "load", augeas_load_old, 0);
     rb_define_method(c_augeas_old, "set_internal", augeas_set_old, 2);
     rb_define_method(c_augeas_old, "setm", augeas_setm, 3);
     rb_define_method(c_augeas_old, "close", augeas_close, 0);

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -78,13 +78,30 @@ VALUE augeas_exists(VALUE s, VALUE path) {
 
 /*
  * call-seq:
- *   set(PATH, VALUE) -> boolean
+ *   set(PATH, VALUE) -> int
  *
  * Set the value associated with PATH to VALUE. VALUE is copied into the
  * internal data structure. Intermediate entries are created if they don't
  * exist.
  */
 VALUE augeas_set(VALUE s, VALUE path, VALUE value) {
+    augeas *aug = aug_handle(s);
+    const char *cpath = StringValueCStr(path) ;
+    const char *cvalue = StringValueCStrOrNull(value) ;
+
+    int callValue = aug_set(aug, cpath, cvalue) ;
+    return INT2FIX(callValue);
+}
+
+/*
+ * call-seq:
+ *   set(PATH, VALUE) -> boolean
+ *
+ * Set the value associated with PATH to VALUE. VALUE is copied into the
+ * internal data structure. Intermediate entries are created if they don't
+ * exist.
+ */
+VALUE augeas_set_old(VALUE s, VALUE path, VALUE value) {
     augeas *aug = aug_handle(s);
     const char *cpath = StringValueCStr(path) ;
     const char *cvalue = StringValueCStrOrNull(value) ;
@@ -444,7 +461,7 @@ void Init__augeas() {
     rb_define_method(c_augeas_old, "match", augeas_match, 1);
     rb_define_method(c_augeas_old, "save", augeas_save, 0);
     rb_define_method(c_augeas_old, "load", augeas_load, 0);
-    rb_define_method(c_augeas_old, "set_internal", augeas_set, 2);
+    rb_define_method(c_augeas_old, "set_internal", augeas_set_old, 2);
     rb_define_method(c_augeas_old, "setm", augeas_setm, 3);
     rb_define_method(c_augeas_old, "close", augeas_close, 0);
     rb_define_method(c_augeas_old, "error", augeas_error, 0);

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -2,6 +2,7 @@
  * augeas.c: Ruby bindings for augeas
  *
  * Copyright (C) 2008 Red Hat Inc.
+ * Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,7 +18,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  *
- * Author: Bryan Kearney <bkearney@redhat.com>
+ * Authors: Bryan Kearney <bkearney@redhat.com>
+ *          Ionuț Arțăriși <iartarisi@suse.cz>
  */
 #include <ruby.h>
 #include <augeas.h>

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -22,6 +22,7 @@
 #include <ruby.h>
 #include <augeas.h>
 
+static VALUE c_augeas_old;
 static VALUE c_augeas;
 
 #define StringValueCStrOrNull(v)                \
@@ -283,7 +284,10 @@ VALUE augeas_defnode(VALUE s, VALUE name, VALUE expr, VALUE value) {
     return (r < 0) ? Qfalse : INT2NUM(r);
 }
 
-VALUE augeas_init(VALUE m, VALUE r, VALUE l, VALUE f) {
+/* This function returns different names for different augeas API */
+/* version specified in the +version+ argument. See augeas_init_old and */
+/* augeas_init. */
+VALUE augeas_init_split(VALUE m, VALUE r, VALUE l, VALUE f, char version) {
     unsigned int flags = NUM2UINT(f);
     const char *root = StringValueCStrOrNull(r);
     const char *loadpath = StringValueCStrOrNull(l);
@@ -293,8 +297,20 @@ VALUE augeas_init(VALUE m, VALUE r, VALUE l, VALUE f) {
     if (aug == NULL) {
         rb_raise(rb_eSystemCallError, "Failed to initialize Augeas");
     }
-    return Data_Wrap_Struct(c_augeas, NULL, augeas_free, aug);
+    if (version == 0) {
+        return Data_Wrap_Struct(c_augeas_old, NULL, augeas_free, aug);
+    } else {
+        return Data_Wrap_Struct(c_augeas, NULL, augeas_free, aug);
+    }
 }
+
+VALUE augeas_init_old(VALUE m, VALUE r, VALUE l, VALUE f) {
+    return augeas_init_split(m, r, l, f, 0);
+}
+VALUE augeas_init(VALUE m, VALUE r, VALUE l, VALUE f) {
+    return augeas_init_split(m, r, l, f, 1);
+}
+
 
 VALUE augeas_close (VALUE s) {
     augeas *aug = aug_handle(s);
@@ -385,10 +401,65 @@ VALUE augeas_span(VALUE s, VALUE path) {
 
 void Init__augeas() {
 
-    /* Define the ruby class */
-    c_augeas = rb_define_class("Augeas", rb_cObject) ;
+    /* Define the OLD ruby class. DEPRECATED. */
+    c_augeas_old = rb_define_class("AugeasOld", rb_cObject) ;
 
     /* Constants for enum aug_flags */
+#define DEF_AUG_FLAG(name) \
+    rb_define_const(c_augeas_old, #name, INT2NUM(AUG_##name))
+    DEF_AUG_FLAG(NONE);
+    DEF_AUG_FLAG(SAVE_BACKUP);
+    DEF_AUG_FLAG(SAVE_NEWFILE);
+    DEF_AUG_FLAG(TYPE_CHECK);
+    DEF_AUG_FLAG(NO_STDINC);
+    DEF_AUG_FLAG(SAVE_NOOP);
+    DEF_AUG_FLAG(NO_LOAD);
+    DEF_AUG_FLAG(NO_MODL_AUTOLOAD);
+    DEF_AUG_FLAG(ENABLE_SPAN);
+#undef DEF_AUG_FLAG
+
+    /* Constants for enum aug_errcode_t */
+#define DEF_AUG_ERR(name) \
+    rb_define_const(c_augeas_old, #name, INT2NUM(AUG_##name))
+    DEF_AUG_ERR(NOERROR);
+    DEF_AUG_ERR(ENOMEM);
+    DEF_AUG_ERR(EINTERNAL);
+    DEF_AUG_ERR(EPATHX);
+    DEF_AUG_ERR(ENOMATCH);
+    DEF_AUG_ERR(EMMATCH);
+    DEF_AUG_ERR(ESYNTAX);
+    DEF_AUG_ERR(ENOLENS);
+    DEF_AUG_ERR(EMXFM);
+#undef DEF_AUG_ERR
+
+    /* Define the methods */
+    rb_define_singleton_method(c_augeas_old, "open3", augeas_init_old, 3);
+    rb_define_method(c_augeas_old, "defvar", augeas_defvar, 2);
+    rb_define_method(c_augeas_old, "defnode", augeas_defnode, 3);
+    rb_define_method(c_augeas_old, "get", augeas_get, 1);
+    rb_define_method(c_augeas_old, "exists", augeas_exists, 1);
+    rb_define_method(c_augeas_old, "insert", augeas_insert, 3);
+    rb_define_method(c_augeas_old, "mv", augeas_mv, 2);
+    rb_define_method(c_augeas_old, "rm", augeas_rm, 1);
+    rb_define_method(c_augeas_old, "match", augeas_match, 1);
+    rb_define_method(c_augeas_old, "save", augeas_save, 0);
+    rb_define_method(c_augeas_old, "load", augeas_load, 0);
+    rb_define_method(c_augeas_old, "set_internal", augeas_set, 2);
+    rb_define_method(c_augeas_old, "setm", augeas_setm, 3);
+    rb_define_method(c_augeas_old, "close", augeas_close, 0);
+    rb_define_method(c_augeas_old, "error", augeas_error, 0);
+    rb_define_method(c_augeas_old, "span", augeas_span, 1);
+
+
+   /* Define the NEW ruby class
+    *
+    * This class is basically the same as the old one, but uses a
+    * different naming scheme for methods (prefixing everything with
+    * "augeas_"). Also some methods point to different C functions.
+    */
+    c_augeas = rb_define_class("Augeas", rb_cObject) ;
+
+/* Constants for enum aug_flags */
 #define DEF_AUG_FLAG(name) \
     rb_define_const(c_augeas, #name, INT2NUM(AUG_##name))
     DEF_AUG_FLAG(NONE);
@@ -402,7 +473,7 @@ void Init__augeas() {
     DEF_AUG_FLAG(ENABLE_SPAN);
 #undef DEF_AUG_FLAG
 
-    /* Constants for enum aug_errcode_t */
+/* Constants for enum aug_errcode_t */
 #define DEF_AUG_ERR(name) \
     rb_define_const(c_augeas, #name, INT2NUM(AUG_##name))
     DEF_AUG_ERR(NOERROR);
@@ -418,21 +489,23 @@ void Init__augeas() {
 
     /* Define the methods */
     rb_define_singleton_method(c_augeas, "open3", augeas_init, 3);
-    rb_define_method(c_augeas, "defvar", augeas_defvar, 2);
-    rb_define_method(c_augeas, "defnode", augeas_defnode, 3);
-    rb_define_method(c_augeas, "get", augeas_get, 1);
-    rb_define_method(c_augeas, "exists", augeas_exists, 1);
-    rb_define_method(c_augeas, "insert", augeas_insert, 3);
-    rb_define_method(c_augeas, "mv", augeas_mv, 2);
-    rb_define_method(c_augeas, "rm", augeas_rm, 1);
-    rb_define_method(c_augeas, "match", augeas_match, 1);
-    rb_define_method(c_augeas, "save", augeas_save, 0);
-    rb_define_method(c_augeas, "load", augeas_load, 0);
-    rb_define_method(c_augeas, "set_internal", augeas_set, 2);
-    rb_define_method(c_augeas, "setm", augeas_setm, 3);
+    rb_define_method(c_augeas, "augeas_defvar", augeas_defvar, 2);
+    rb_define_method(c_augeas, "augeas_defnode", augeas_defnode, 3);
+    rb_define_method(c_augeas, "augeas_get", augeas_get, 1);
+    rb_define_method(c_augeas, "augeas_exists", augeas_exists, 1);
+    rb_define_method(c_augeas, "augeas_insert", augeas_insert, 3);
+    rb_define_method(c_augeas, "augeas_mv", augeas_mv, 2);
+    rb_define_method(c_augeas, "augeas_rm", augeas_rm, 1);
+    rb_define_method(c_augeas, "augeas_match", augeas_match, 1);
+    rb_define_method(c_augeas, "augeas_save", augeas_save, 0);
+    rb_define_method(c_augeas, "augeas_load", augeas_load, 0);
+    rb_define_method(c_augeas, "augeas_set", augeas_set, 2);
+    rb_define_method(c_augeas, "augeas_setm", augeas_setm, 3);
+    /* The `close` and `error` methods as used unchanged in the ruby bindings */
     rb_define_method(c_augeas, "close", augeas_close, 0);
     rb_define_method(c_augeas, "error", augeas_error, 0);
-    rb_define_method(c_augeas, "span", augeas_span, 1);
+    rb_define_method(c_augeas, "augeas_span", augeas_span, 1);
+    
 }
 
 /*

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -485,6 +485,9 @@ void Init__augeas() {
     DEF_AUG_ERR(ESYNTAX);
     DEF_AUG_ERR(ENOLENS);
     DEF_AUG_ERR(EMXFM);
+    DEF_AUG_ERR(ENOSPAN);
+    DEF_AUG_ERR(EMVDESC);
+    DEF_AUG_ERR(ECMDRUN);
 #undef DEF_AUG_ERR
 
     /* Define the methods */

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -191,8 +191,37 @@ VALUE augeas_rm(VALUE s, VALUE path, VALUE sibling) {
  *
  * Return all the paths that match the path expression PATH as an aray of
  * strings.
+ * Returns an empty array if no paths were found.
  */
 VALUE augeas_match(VALUE s, VALUE p) {
+    augeas *aug = aug_handle(s);
+    const char *path = StringValueCStr(p);
+    char **matches = NULL;
+    int cnt, i;
+
+    cnt = aug_match(aug, path, &matches) ;
+    if (cnt < 0)
+        return -1;
+
+    VALUE result = rb_ary_new();
+    for (i = 0; i < cnt; i++) {
+        rb_ary_push(result, rb_str_new(matches[i], strlen(matches[i])));
+        free(matches[i]) ;
+    }
+    free (matches) ;
+
+    return result ;
+}
+
+/*
+ * call-seq:
+ *       match(PATH) -> an_array
+ *
+ * Return all the paths that match the path expression PATH as an aray of
+ * strings.
+ * Raises an error if no paths were found.
+ */
+VALUE augeas_match_old(VALUE s, VALUE p) {
     augeas *aug = aug_handle(s);
     const char *path = StringValueCStr(p);
     char **matches = NULL;
@@ -458,7 +487,7 @@ void Init__augeas() {
     rb_define_method(c_augeas_old, "insert", augeas_insert, 3);
     rb_define_method(c_augeas_old, "mv", augeas_mv, 2);
     rb_define_method(c_augeas_old, "rm", augeas_rm, 1);
-    rb_define_method(c_augeas_old, "match", augeas_match, 1);
+    rb_define_method(c_augeas_old, "match", augeas_match_old, 1);
     rb_define_method(c_augeas_old, "save", augeas_save, 0);
     rb_define_method(c_augeas_old, "load", augeas_load, 0);
     rb_define_method(c_augeas_old, "set_internal", augeas_set_old, 2);

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -41,7 +41,7 @@ class Augeas
   class MultipleTransformsError < Error; end
   class NoSpanInfoError         < Error; end
   class DescendantError         < Error; end
-  class CmdExecError            < Error; end
+  class CommandExecutionError   < Error; end
   @@error_hash = {
     # the cryptic error names come from the C library, we just make
     # them more ruby and more human
@@ -55,7 +55,7 @@ class Augeas
     EMXFM     => MultipleTransformsError,
     ENOSPAN   => NoSpanInfoError,
     EMVDESC   => DescendantError,
-    ECMDRUN   => CmdExecError }
+    ECMDRUN   => CommandExecutionError}
 
 
   # DEPRECATED. Create a new Augeas instance and return it.

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -126,5 +126,5 @@ class Augeas
 
     return result
   end
-    
+  
 end

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -76,7 +76,7 @@ class Augeas
     return AugeasOld.open(root, loadpath, flags)
   end
 
-  def self.create
-    return Augeas.open
+  def self.create(root=nil, loadpath=nil, flags=Augeas::NONE, &block)
+    return Augeas.open3(nil, nil, Augeas::NONE)
   end
 end

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -78,8 +78,9 @@ class Augeas
     return AugeasOld::open(root, loadpath, flags, &block)
   end
 
-  def self.create(root=nil, loadpath=nil, flags=Augeas::NONE, &block)
-    aug = Augeas.open3(root, loadpath, flags)
+  def self.create(opts={:root=> nil, :loadpath=>nil, :flags=>Augeas::NONE},
+                  &block)
+    aug = Augeas.open3(opts[:root], opts[:loadpath], opts[:flags])
     if block_given?
       begin
         yield aug

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -79,7 +79,16 @@ class Augeas
   end
 
   def self.create(root=nil, loadpath=nil, flags=Augeas::NONE, &block)
-    return Augeas.open3(root, loadpath, flags)
+    aug = Augeas.open3(root, loadpath, flags)
+    if block_given?
+      begin
+        yield aug
+      ensure
+        aug.close
+      end
+    else
+      return aug
+    end
   end
 
   # Get the value associated with +path+.

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -25,7 +25,6 @@
 require "_augeas"
 require "augeas_old"
 
-
 # Wrapper class for the augeas[http://augeas.net] library.
 class Augeas
   private_class_method :new
@@ -57,8 +56,7 @@ class Augeas
     EMVDESC   => DescendantError,
     ECMDRUN   => CommandExecutionError}
 
-
-  # DEPRECATED. Create a new Augeas instance and return it.
+  # DEPRECATED - use create instead. Create a new Augeas instance and return it.
   #
   # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
   # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
@@ -91,7 +89,6 @@ class Augeas
   # The following flags can be specified in a hash. They all default to
   # false and can be enabled by setting them to true
   #
-  #
   # :type_check - typecheck lenses (since it can be very expensive it is
   # not done by default)
   #
@@ -113,9 +110,8 @@ class Augeas
   #   do not overwrite the original file.
   #
   # When a block is given, the Augeas instance is passed as the only
-  # argument into the block and closed when the block exits. In that
-  # case, the return value of the block is the return value of
-  # +open+. With no block, the Augeas instance is returned.
+  # argument into the block and closed when the block exits.
+  # With no block, the Augeas instance is returned.
   def self.create(opts={}, &block)
     # aug_flags is a bitmask in the underlying library, we add all the
     # values of the flags which were set to true to the default value

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -96,6 +96,11 @@ class Augeas
     run_command :augeas_get, path
   end
 
+  # Return true if there is an entry for this path, false otherwise
+  def exists(path)
+    run_command :augeas_exists, path
+  end
+
   # Set one or multiple elements to path.
   # Multiple elements are mainly sensible with a path like
   # .../array[last()+1], since this will append all elements.
@@ -127,6 +132,27 @@ class Augeas
   # Raises an <tt>Augeas::InvalidPathError</tt> when the +path+ is invalid.
   def match(path)
     run_command :augeas_match, path
+  end
+
+  # Evaluate +expr+ and set the variable +name+ to the resulting
+  # nodeset. The variable can be used in path expressions as $name.
+  # Note that +expr+ is evaluated when the variable is defined, not when
+  # it is used.
+  def defvar(name, expr)
+    run_command :augeas_defvar, name, expr
+  end
+
+  # Define the variable +name+ to the result of evaluating +expr+, which
+  # must be a nodeset.  If no node matching +expr+ exists yet, one is
+  # created and +name+ will refer to it.  When a node is created and
+  # +value+ is given, the new node's value is set to +value+.
+  def defnode(name, expr, value=nil)
+    run_command :augeas_defnode, name, expr, value
+  end
+
+  # Clear the +path+, i.e. make its value +nil+
+  def clear(path)
+    augeas_set(path, nil)
   end
 
   # Add a transform under <tt>/augeas/load</tt>

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -117,6 +117,19 @@ class Augeas
   def match(path)
     run_command :augeas_match, path
   end
+
+  # Write all pending changes to disk.
+  # Raises <tt>Augeas::CommandExecutionError</tt> if saving fails.
+  def save
+    begin
+      run_command :augeas_save
+    rescue Augeas::CommandExecutionError => e
+      raise e, "Saving failed. Search the augeas tree in /augeas//error"+
+        "for the actual errors."
+    end
+
+    nil
+  end
   
   private
 

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -118,6 +118,37 @@ class Augeas
     run_command :augeas_match, path
   end
 
+  # Add a transform under <tt>/augeas/load</tt>
+  #
+  # The HASH can contain the following entries
+  # * <tt>:lens</tt> - the name of the lens to use
+  # * <tt>:name</tt> - a unique name; use the module name of the LENS
+  # when omitted
+  # * <tt>:incl</tt> - a list of glob patterns for the files to transform
+  # * <tt>:excl</tt> - a list of the glob patterns to remove from the
+  # list that matches <tt>:incl</tt>
+  def transform(hash)
+    lens = hash[:lens]
+    name = hash[:name]
+    incl = hash[:incl]
+    excl = hash[:excl]
+    raise ArgumentError, "No lens specified" unless lens
+    raise ArgumentError, "No files to include" unless incl
+    name = lens.split(".")[0].sub("@", "") unless name
+
+    xfm = "/augeas/load/#{name}/"
+    set(xfm + "lens", lens)
+    set(xfm + "incl[last()+1]", incl)
+    set(xfm + "excl[last()+1]", excl) if excl
+  end
+
+  # Clear all transforms under <tt>/augeas/load</tt>. If +load+
+  # is called right after this, there will be no files
+  # under +/files+
+  def clear_transforms
+    rm("/augeas/load/*")
+  end
+  
   # Write all pending changes to disk.
   # Raises <tt>Augeas::CommandExecutionError</tt> if saving fails.
   def save

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -137,8 +137,14 @@ class Augeas
     opts.each_key do |key|
       if flags.key? key
         aug_flags += flags[key]
-      elsif key == :save_mode && save_modes[opts[:save_mode]]
-        aug_flags += save_modes[opts[:save_mode]]
+      elsif key == :save_mode
+        if save_modes[opts[:save_mode]]
+          aug_flags += save_modes[opts[:save_mode]]
+        else
+          raise ArgumentError, "Invalid save mode #{opts[:save_mode]}."
+        end
+      elsif key != :root && key != :loadpath
+        raise ArgumentError, "Unknown argument #{key}."
       end
     end
 

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -73,7 +73,7 @@ class Augeas
   # case, the return value of the block is the return value of
   # +open+. With no block, the Augeas instance is returned.
   def self.open(root=nil, loadpath=nil, flags=Augeas::NONE, &block)
-    return AugeasOld.open(root, loadpath, flags)
+    return AugeasOld::open(root, loadpath, flags, &block)
   end
 
   def self.create(root=nil, loadpath=nil, flags=Augeas::NONE, &block)

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -101,6 +101,14 @@ class Augeas
     run_command :augeas_rm, path
   end
 
+  # Return an Array of all the paths that match the path expression +path+
+  #
+  # Returns an empty Array if no paths were found.
+  # Raises an <tt>Augeas::InvalidPathError</tt> when the +path+ is invalid.
+  def match(path)
+    run_command :augeas_match, path
+  end
+  
   private
 
   # Run a command and raise any errors that happen due to execution.

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -103,6 +103,17 @@ class Augeas
     values.flatten.each { |v| run_command :augeas_set, path, v }
   end
 
+  # Set multiple nodes in one operation.  Find or create a node matching SUB
+  # by interpreting SUB as a  path expression relative to each node matching
+  # BASE. If SUB is '.', the nodes matching BASE will be modified.
+
+  # +base+    the base node
+  # +sub+     the subtree relative to the base
+  # +value+   the value for the nodes
+  def setm(base, sub, value)
+    run_command :augeas_setm, base, sub, value
+  end
+
   # Remove all nodes matching path expression +path+ and all their
   # children.
   # Raises an <tt>Augeas::InvalidPathError</tt> when the +path+ is invalid.
@@ -179,6 +190,38 @@ class Augeas
     end
 
     nil
+  end
+
+  # Move node +src+ to +dst+. +src+ must match exactly one node in
+  # the tree. +dst+ must either match exactly one node in the tree,
+  # or may not exist yet. If +dst+ exists already, it and all its
+  # descendants are deleted. If +dst+ does not exist yet, it and all
+  # its missing ancestors are created.
+  #
+  # Raises <tt>Augeas::NoMatchError</tt> if the +src+ node does not exist
+  # Raises <tt>Augeas::MultipleMatchesError</tt> if there were
+  # multiple matches in +src+
+  # Raises <tt>Augeas::DescendantError</tt> if the +dst+ node is a
+  # descendant of the +src+ node.
+  def mv(src, dst)
+    run_command :augeas_mv, src, dst
+  end
+
+  # Get the filename, label and value position in the text of this node
+  #
+  # Raises <tt>Augeas::NoMatchError</tt> if the node could not be found
+  # Raises <tt>Augeas::NoSpanInfo</tt> if the node associated with
+  # +path+ doesn't belong to a file or doesn't exist
+  def span(path)
+    run_command :augeas_span, path
+  end
+
+  # Make +label+ a sibling of +path+ by inserting it directly before
+  # or after +path+.
+  # The boolean +before+ determines if +label+ is inserted before or
+  # after +path+.
+  def insert(path, label, before)
+    run_command :augeas_insert, path, label, before
   end
 
   private

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -131,6 +131,25 @@ class Augeas
     nil
   end
   
+  # Load files according to the transforms in /augeas/load or those
+  # defined via <tt>transform</tt>.  A transform Foo is represented
+  # with a subtree /augeas/load/Foo.  Underneath /augeas/load/Foo, one
+  # node labeled 'lens' must exist, whose value is the fully
+  # qualified name of a lens, for example 'Foo.lns', and multiple
+  # nodes 'incl' and 'excl' whose values are globs that determine
+  # which files are transformed by that lens. It is an error if one
+  # file can be processed by multiple transforms.
+  def load
+    begin
+      run_command :augeas_load
+    rescue Augeas::CommandExecutionError => e
+      raise e, "Loading failed. Search the augeas tree in /augeas//error"+
+        "for the actual errors."
+    end
+
+    nil
+  end
+
   private
 
   # Run a command and raise any errors that happen due to execution.

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -21,13 +21,40 @@
 ##
 
 require "_augeas"
-
 require "augeas_old"
 
+
+# Wrapper class for the augeas[http://augeas.net] library.
 class Augeas
   private_class_method :new
 
-  class Error < RuntimeError; end
+  class Error                   < RuntimeError; end
+  class NoMemoryError           < Error; end
+  class InternalError           < Error; end
+  class InvalidPathError        < Error; end
+  class NoMatchError            < Error; end
+  class MultipleMatchesError    < Error; end
+  class LensSyntaxError         < Error; end
+  class LensNotFoundError       < Error; end
+  class MultipleTransformsError < Error; end
+  class NoSpanInfoError         < Error; end
+  class DescendantError         < Error; end
+  class CmdExecError            < Error; end
+  @@error_hash = {
+    # the cryptic error names come from the C library, we just make
+    # them more ruby and more human
+    ENOMEM    => NoMemoryError,
+    EINTERNAL => InternalError,
+    EPATHX    => InvalidPathError,
+    ENOMATCH  => NoMatchError,
+    EMMATCH   => MultipleMatchesError,
+    ESYNTAX   => LensSyntaxError,
+    ENOLENS   => LensNotFoundError,
+    EMXFM     => MultipleTransformsError,
+    ENOSPAN   => NoSpanInfoError,
+    EMVDESC   => DescendantError,
+    ECMDRUN   => CmdExecError }
+
 
   # DEPRECATED. Create a new Augeas instance and return it.
   #

--- a/lib/augeas.rb
+++ b/lib/augeas.rb
@@ -1,7 +1,7 @@
 ##
 #  augeas.rb: Ruby wrapper for augeas
 #
-#  Copyright (C) 2008 Red Hat Inc.
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
 #
 #  This library is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU Lesser General Public
@@ -17,103 +17,39 @@
 #  License along with this library; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 #
-# Author: Bryan Kearney <bkearney@redhat.com>
+# Author: Ionuț Arțăriși <iartarisi@suse.cz>
 ##
 
 require "_augeas"
 
-# Wrapper class for the augeas[http://augeas.net] library.
+require "augeas_old"
+
 class Augeas
-    private_class_method :new
+  private_class_method :new
 
-    class Error < RuntimeError; end
+  class Error < RuntimeError; end
 
-    # Create a new Augeas instance and return it.
-    #
-    # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
-    # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
-    # either, use "/".
-    #
-    # +loadpath+ is a colon-spearated list of directories that modules
-    # should be searched in. This is in addition to the standard load path
-    # and the directories in +AUGEAS_LENS_LIB+
-    #
-    # +flags+ is a bitmask (see <tt>enum aug_flags</tt>)
-    #
-    # When a block is given, the Augeas instance is passed as the only
-    # argument into the block and closed when the block exits. In that
-    # case, the return value of the block is the return value of
-    # +open+. With no block, the Augeas instance is returned.
-    def self.open(root = nil, loadpath = nil, flags = NONE, &block)
-        aug = open3(root, loadpath, flags)
-        if block_given?
-            begin
-                rv = yield aug
-                return rv
-            ensure
-                aug.close
-            end
-        else
-            return aug
-        end
-    end
+  # DEPRECATED. Create a new Augeas instance and return it.
+  #
+  # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
+  # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
+  # either, use "/".
+  #
+  # +loadpath+ is a colon-spearated list of directories that modules
+  # should be searched in. This is in addition to the standard load path
+  # and the directories in +AUGEAS_LENS_LIB+
+  #
+  # +flags+ is a bitmask (see <tt>enum aug_flags</tt>)
+  #
+  # When a block is given, the Augeas instance is passed as the only
+  # argument into the block and closed when the block exits. In that
+  # case, the return value of the block is the return value of
+  # +open+. With no block, the Augeas instance is returned.
+  def self.open(root=nil, loadpath=nil, flags=Augeas::NONE, &block)
+    return AugeasOld.open(root, loadpath, flags)
+  end
 
-    # Set one or multiple elemens to path.
-    # Multiple elements are mainly sensible with a path like
-    # .../array[last()+1], since this will append all elements.
-    def set(path, *values)
-        values.flatten.each { |v| set_internal(path, v) }
-    end
-
-    # The same as +set+, but raises <tt>Augeas::Error</tt> if setting fails
-    def set!(path, *values)
-        values.flatten.each do |v|
-            raise Augeas::Error unless set_internal(path, v)
-        end
-    end
-
-    # Clear the +path+, i.e. make its value +nil+
-    def clear(path)
-        set_internal(path, nil)
-    end
-
-    # Clear all transforms under <tt>/augeas/load</tt>. If +load+
-    # is called right after this, there will be no files
-    # under +/files+
-    def clear_transforms
-        rm("/augeas/load/*")
-    end
-
-    # Add a transform under <tt>/augeas/load</tt>
-    #
-    # The HASH can contain the following entries
-    # * <tt>:lens</tt> - the name of the lens to use
-    # * <tt>:name</tt> - a unique name; use the module name of the LENS when omitted
-    # * <tt>:incl</tt> - a list of glob patterns for the files to transform
-    # * <tt>:excl</tt> - a list of the glob patterns to remove from the list that matches <tt>:INCL</tt>
-    def transform(hash)
-        lens = hash[:lens]
-        name = hash[:name]
-        incl = hash[:incl]
-        excl = hash[:excl]
-        raise ArgumentError, "No lens specified" unless lens
-        raise ArgumentError, "No files to include" unless incl
-        name = lens.split(".")[0].sub("@", "") unless name
-
-        xfm = "/augeas/load/#{name}/"
-        set(xfm + "lens", lens)
-        set(xfm + "incl[last()+1]", incl)
-        set(xfm + "excl[last()+1]", excl) if excl
-    end
-
-    # The same as +save+, but raises <tt>Augeas::Error</tt> if saving fails
-    def save!
-        raise Augeas::Error unless save
-    end
-
-    # The same as +load+, but raises <tt>Augeas::Error</tt> if loading fails
-    def load!
-        raise Augeas::Error unless load
-    end
-
+  def self.create
+    return Augeas.open
+  end
 end

--- a/lib/augeas_old.rb
+++ b/lib/augeas_old.rb
@@ -26,96 +26,96 @@ require "_augeas"
 
 # Old (deprecated) wrapper class for the augeas[http://augeas.net] library.
 class AugeasOld
-    private_class_method :new
+  private_class_method :new
 
-    class Error < RuntimeError; end
+  class Error < RuntimeError; end
 
-    # Create a new Augeas instance and return it.
-    #
-    # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
-    # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
-    # either, use "/".
-    #
-    # +loadpath+ is a colon-spearated list of directories that modules
-    # should be searched in. This is in addition to the standard load path
-    # and the directories in +AUGEAS_LENS_LIB+
-    #
-    # +flags+ is a bitmask (see <tt>enum aug_flags</tt>)
-    #
-    # When a block is given, the Augeas instance is passed as the only
-    # argument into the block and closed when the block exits. In that
-    # case, the return value of the block is the return value of
-    # +open+. With no block, the Augeas instance is returned.
-    def self.open(root = nil, loadpath = nil, flags = AugeasOld::NONE, &block)
-        aug = AugeasOld::open3(root, loadpath, flags)
-        if block_given?
-            begin
-                rv = yield aug
-                return rv
-            ensure
-                aug.close
-            end
-        else
-            return aug
-        end
+  # Create a new Augeas instance and return it.
+  #
+  # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
+  # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
+  # either, use "/".
+  #
+  # +loadpath+ is a colon-spearated list of directories that modules
+  # should be searched in. This is in addition to the standard load path
+  # and the directories in +AUGEAS_LENS_LIB+
+  #
+  # +flags+ is a bitmask (see <tt>enum aug_flags</tt>)
+  #
+  # When a block is given, the Augeas instance is passed as the only
+  # argument into the block and closed when the block exits. In that
+  # case, the return value of the block is the return value of
+  # +open+. With no block, the Augeas instance is returned.
+  def self.open(root = nil, loadpath = nil, flags = AugeasOld::NONE, &block)
+    aug = AugeasOld::open3(root, loadpath, flags)
+    if block_given?
+      begin
+        rv = yield aug
+        return rv
+      ensure
+        aug.close
+      end
+    else
+      return aug
     end
+  end
 
-    # Set one or multiple elemens to path.
-    # Multiple elements are mainly sensible with a path like
-    # .../array[last()+1], since this will append all elements.
-    def set(path, *values)
-        values.flatten.each { |v| set_internal(path, v) }
+  # Set one or multiple elemens to path.
+  # Multiple elements are mainly sensible with a path like
+  # .../array[last()+1], since this will append all elements.
+  def set(path, *values)
+    values.flatten.each { |v| set_internal(path, v) }
+  end
+
+  # The same as +set+, but raises <tt>Augeas::Error</tt> if setting fails
+  def set!(path, *values)
+    values.flatten.each do |v|
+      raise Augeas::Error unless set_internal(path, v)
     end
+  end
 
-    # The same as +set+, but raises <tt>Augeas::Error</tt> if setting fails
-    def set!(path, *values)
-        values.flatten.each do |v|
-            raise Augeas::Error unless set_internal(path, v)
-        end
-    end
+  # Clear the +path+, i.e. make its value +nil+
+  def clear(path)
+    set_internal(path, nil)
+  end
 
-    # Clear the +path+, i.e. make its value +nil+
-    def clear(path)
-        set_internal(path, nil)
-    end
+  # Clear all transforms under <tt>/augeas/load</tt>. If +load+
+  # is called right after this, there will be no files
+  # under +/files+
+  def clear_transforms
+    rm("/augeas/load/*")
+  end
 
-    # Clear all transforms under <tt>/augeas/load</tt>. If +load+
-    # is called right after this, there will be no files
-    # under +/files+
-    def clear_transforms
-        rm("/augeas/load/*")
-    end
+  # Add a transform under <tt>/augeas/load</tt>
+  #
+  # The HASH can contain the following entries
+  # * <tt>:lens</tt> - the name of the lens to use
+  # * <tt>:name</tt> - a unique name; use the module name of the LENS when omitted
+  # * <tt>:incl</tt> - a list of glob patterns for the files to transform
+  # * <tt>:excl</tt> - a list of the glob patterns to remove from the list that matches <tt>:INCL</tt>
+  def transform(hash)
+    lens = hash[:lens]
+    name = hash[:name]
+    incl = hash[:incl]
+    excl = hash[:excl]
+    raise ArgumentError, "No lens specified" unless lens
+    raise ArgumentError, "No files to include" unless incl
+    name = lens.split(".")[0].sub("@", "") unless name
 
-    # Add a transform under <tt>/augeas/load</tt>
-    #
-    # The HASH can contain the following entries
-    # * <tt>:lens</tt> - the name of the lens to use
-    # * <tt>:name</tt> - a unique name; use the module name of the LENS when omitted
-    # * <tt>:incl</tt> - a list of glob patterns for the files to transform
-    # * <tt>:excl</tt> - a list of the glob patterns to remove from the list that matches <tt>:INCL</tt>
-    def transform(hash)
-        lens = hash[:lens]
-        name = hash[:name]
-        incl = hash[:incl]
-        excl = hash[:excl]
-        raise ArgumentError, "No lens specified" unless lens
-        raise ArgumentError, "No files to include" unless incl
-        name = lens.split(".")[0].sub("@", "") unless name
+    xfm = "/augeas/load/#{name}/"
+    set(xfm + "lens", lens)
+    set(xfm + "incl[last()+1]", incl)
+    set(xfm + "excl[last()+1]", excl) if excl
+  end
 
-        xfm = "/augeas/load/#{name}/"
-        set(xfm + "lens", lens)
-        set(xfm + "incl[last()+1]", incl)
-        set(xfm + "excl[last()+1]", excl) if excl
-    end
+  # The same as +save+, but raises <tt>Augeas::Error</tt> if saving fails
+  def save!
+    raise Augeas::Error unless save
+  end
 
-    # The same as +save+, but raises <tt>Augeas::Error</tt> if saving fails
-    def save!
-        raise Augeas::Error unless save
-    end
-
-    # The same as +load+, but raises <tt>Augeas::Error</tt> if loading fails
-    def load!
-        raise Augeas::Error unless load
-    end
+  # The same as +load+, but raises <tt>Augeas::Error</tt> if loading fails
+  def load!
+    raise Augeas::Error unless load
+  end
 
 end

--- a/lib/augeas_old.rb
+++ b/lib/augeas_old.rb
@@ -1,0 +1,121 @@
+##
+#  augeas.rb: Ruby wrapper for augeas
+#
+#  Copyright (C) 2008 Red Hat Inc.
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+# Authors: Bryan Kearney <bkearney@redhat.com>
+#          Ionuț Arțăriși <iartarisi@suse.cz>
+##
+
+require "_augeas"
+
+# Old (deprecated) wrapper class for the augeas[http://augeas.net] library.
+class AugeasOld
+    private_class_method :new
+
+    class Error < RuntimeError; end
+
+    # Create a new Augeas instance and return it.
+    #
+    # Use +root+ as the filesystem root. If +root+ is +nil+, use the value
+    # of the environment variable +AUGEAS_ROOT+. If that doesn't exist
+    # either, use "/".
+    #
+    # +loadpath+ is a colon-spearated list of directories that modules
+    # should be searched in. This is in addition to the standard load path
+    # and the directories in +AUGEAS_LENS_LIB+
+    #
+    # +flags+ is a bitmask (see <tt>enum aug_flags</tt>)
+    #
+    # When a block is given, the Augeas instance is passed as the only
+    # argument into the block and closed when the block exits. In that
+    # case, the return value of the block is the return value of
+    # +open+. With no block, the Augeas instance is returned.
+    def self.open(root = nil, loadpath = nil, flags = AugeasOld::NONE, &block)
+        aug = AugeasOld::open3(root, loadpath, flags)
+        if block_given?
+            begin
+                rv = yield aug
+                return rv
+            ensure
+                aug.close
+            end
+        else
+            return aug
+        end
+    end
+
+    # Set one or multiple elemens to path.
+    # Multiple elements are mainly sensible with a path like
+    # .../array[last()+1], since this will append all elements.
+    def set(path, *values)
+        values.flatten.each { |v| set_internal(path, v) }
+    end
+
+    # The same as +set+, but raises <tt>Augeas::Error</tt> if setting fails
+    def set!(path, *values)
+        values.flatten.each do |v|
+            raise Augeas::Error unless set_internal(path, v)
+        end
+    end
+
+    # Clear the +path+, i.e. make its value +nil+
+    def clear(path)
+        set_internal(path, nil)
+    end
+
+    # Clear all transforms under <tt>/augeas/load</tt>. If +load+
+    # is called right after this, there will be no files
+    # under +/files+
+    def clear_transforms
+        rm("/augeas/load/*")
+    end
+
+    # Add a transform under <tt>/augeas/load</tt>
+    #
+    # The HASH can contain the following entries
+    # * <tt>:lens</tt> - the name of the lens to use
+    # * <tt>:name</tt> - a unique name; use the module name of the LENS when omitted
+    # * <tt>:incl</tt> - a list of glob patterns for the files to transform
+    # * <tt>:excl</tt> - a list of the glob patterns to remove from the list that matches <tt>:INCL</tt>
+    def transform(hash)
+        lens = hash[:lens]
+        name = hash[:name]
+        incl = hash[:incl]
+        excl = hash[:excl]
+        raise ArgumentError, "No lens specified" unless lens
+        raise ArgumentError, "No files to include" unless incl
+        name = lens.split(".")[0].sub("@", "") unless name
+
+        xfm = "/augeas/load/#{name}/"
+        set(xfm + "lens", lens)
+        set(xfm + "incl[last()+1]", incl)
+        set(xfm + "excl[last()+1]", excl) if excl
+    end
+
+    # The same as +save+, but raises <tt>Augeas::Error</tt> if saving fails
+    def save!
+        raise Augeas::Error unless save
+    end
+
+    # The same as +load+, but raises <tt>Augeas::Error</tt> if loading fails
+    def load!
+        raise Augeas::Error unless load
+    end
+
+end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -180,9 +180,14 @@ class TestAugeas < Test::Unit::TestCase
                  aug.get("/augeas/files/etc/sysconfig/iptables/error/message"))
   end
 
-  def test_set!
+  def test_set_invalid_path
     aug = aug_open
-    assert_raises(Augeas::Error) { aug.set!("files/etc/hosts/*", nil) }
+    assert_raises(Augeas::InvalidPathError) { aug.set("files/etc//", nil) }
+  end
+
+  def test_set_multiple_matches_error
+    aug = aug_open
+    assert_raises(Augeas::MultipleMatchesError) { aug.set("files/etc/*", nil) }
   end
 
   def test_set

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -1,5 +1,26 @@
-# These tests are run against the old deprecated module which is
-# instantiated by Augeas::open
+##
+#  Augeas tests
+#
+#  Copyright (C) 2011 Red Hat Inc.
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+# Authors: David Lutterkort <dlutter@redhat.com>
+#          Ionuț Arțăriși <iartarisi@suse.cz>
+##
 
 require 'test/unit'
 

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -226,18 +226,6 @@ class TestAugeas < Test::Unit::TestCase
     assert_equal(aug.get("/files/etc/group/rpcuser/users"), "testuser2")
   end
 
-  def test_error
-    aug = aug_open
-
-    # Cause an error
-    aug.get("/files/etc/hosts/*")
-    err = aug.error
-    assert_equal(Augeas::EMMATCH, err[:code])
-    assert err[:message]
-    assert err[:details]
-    assert err[:minor].nil?
-  end
-
   def test_get_multiple_matches_error
     aug = aug_open
 

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -140,7 +140,7 @@ class TestAugeas < Test::Unit::TestCase
     aug = aug_open(Augeas::NO_LOAD)
     aug.transform(:lens => "bad_lens", :incl => "irrelevant")
     assert_raises(Augeas::LensNotFoundError) { aug.load }
-    assert_equal aug.error[:details], "Could not find lens bad_lens"
+    assert_equal aug.error[:details], "Can not find lens bad_lens"
   end
 
   def test_transform

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -45,6 +45,15 @@ class TestAugeas < Test::Unit::TestCase
     end
   end
 
+  def test_create_block
+    foo = nil
+    Augeas::create do |aug|
+      aug.set('/foo', 'bar')
+      foo = aug.get('/foo')
+    end
+    assert_equal(foo, 'bar')
+  end
+
   def test_close
     aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
     assert_equal("newfile", aug.get("/augeas/save"))

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -66,6 +66,18 @@ class TestAugeas < Test::Unit::TestCase
     end
   end
 
+  def test_create_unknown_argument
+    assert_raise ArgumentError do
+      Augeas::create(:bogus => false)
+    end
+  end
+
+  def test_create_invalid_save_mode
+    assert_raise ArgumentError do
+      Augeas::create(:save_mode => :bogus)
+    end
+  end
+
   def test_create_block
     foo = nil
     Augeas::create do |aug|

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -38,7 +38,7 @@ class TestAugeas < Test::Unit::TestCase
   TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
 
   def test_basics
-    aug = aug_create(:save_newfile => true)
+    aug = aug_create(:save_mode => :newfile)
     assert_equal("newfile", aug.get("/augeas/save"))
     assert_equal(TST_ROOT, aug.get("/augeas/root"))
 
@@ -76,7 +76,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_close
-    aug = Augeas::create(:root => "/tmp", :save_newfile => true)
+    aug = Augeas::create(:root => "/tmp", :save_mode => :newfile)
     assert_equal("newfile", aug.get("/augeas/save"))
     aug.close
 
@@ -426,7 +426,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_flag_save_noop
-    aug = aug_create(:save_noop => true)
+    aug = aug_create(:save_mode => :noop)
     assert_equal("noop", aug.get("/augeas/save"))
   end
 

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -86,6 +86,13 @@ class TestAugeas < Test::Unit::TestCase
     assert_equal([], aug.match("/files/etc/*"))
   end
 
+  def test_load_bad_lens
+    aug = aug_open(Augeas::NO_LOAD)
+    aug.transform(:lens => "bad_lens", :incl => "irrelevant")
+    assert_raises(Augeas::LensNotFoundError) { aug.load }
+    assert_equal aug.error[:details], "Could not find lens bad_lens"
+  end
+
   def test_transform
     aug = aug_open(Augeas::NO_LOAD)
     aug.clear_transforms

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -137,6 +137,25 @@ class TestAugeas < Test::Unit::TestCase
     assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
   end
 
+  def test_match
+    aug = aug_open
+    aug.set("/foo/bar", "baz")
+    aug.set("/foo/baz", "qux")
+    aug.set("/foo/qux", "bar")
+
+    assert_equal(["/foo/bar", "/foo/baz", "/foo/qux"], aug.match("/foo/*"))
+  end
+
+  def test_match_empty_list
+    aug = aug_open
+    assert_equal([], aug.match("/nonexistent"))
+  end
+
+  def test_match_invalid_path
+    aug = aug_open
+    assert_raises(Augeas::InvalidPathError) { aug.match('//') }
+  end
+
   def test_save!
     aug = aug_open
     aug.set("/files/etc/hosts/1/garbage", "trash")

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -434,6 +434,6 @@ class TestAugeas < Test::Unit::TestCase
     FileUtils::mkdir_p(TST_ROOT)
     FileUtils::cp_r(SRC_ROOT, TST_ROOT)
 
-    Augeas::create(TST_ROOT, nil, flags)
+    Augeas::create(:root => TST_ROOT, :loadpath => nil, :flags => flags)
   end
 end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -141,6 +141,19 @@ class TestAugeas < Test::Unit::TestCase
                  aug.match("/files/etc/*").sort)
   end
 
+  def test_transform_invalid_path
+    aug = aug_open
+    assert_raises (Augeas::InvalidPathError) {
+      aug.transform :lens => '//', :incl => 'foo' }
+  end
+
+  def test_clear_transforms
+    aug = aug_open
+    assert_not_equal [], aug.match("/augeas/load/*")
+    aug.clear_transforms
+    assert_equal [], aug.match("/augeas/load/*")
+  end
+
   def test_rm
     aug = aug_open
     aug.set("/foo/bar", "baz")

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -38,7 +38,7 @@ class TestAugeas < Test::Unit::TestCase
   TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
 
   def test_basics
-    aug = aug_create(Augeas::SAVE_NEWFILE)
+    aug = aug_create(:save_newfile => true)
     assert_equal("newfile", aug.get("/augeas/save"))
     assert_equal(TST_ROOT, aug.get("/augeas/root"))
 
@@ -76,7 +76,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_close
-    aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
+    aug = Augeas::create(:root => "/tmp", :save_newfile => true)
     assert_equal("newfile", aug.get("/augeas/save"))
     aug.close
 
@@ -90,7 +90,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_mv
-    Augeas::open("/dev/null") do |aug|
+    Augeas::create(:root => "/dev/null") do |aug|
       aug.set("/a/b", "value")
       aug.mv("/a/b", "/x/y")
       assert_equal("value", aug.get("/x/y"))
@@ -127,7 +127,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_load
-    aug = aug_create(Augeas::NO_LOAD)
+    aug = aug_create(:no_load => true)
     assert_equal([], aug.match("/files/etc/*"))
     aug.rm("/augeas/load/*");
     assert_nothing_raised {
@@ -137,14 +137,14 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_load_bad_lens
-    aug = aug_create(Augeas::NO_LOAD)
+    aug = aug_create(:no_load => true)
     aug.transform(:lens => "bad_lens", :incl => "irrelevant")
     assert_raises(Augeas::LensNotFoundError) { aug.load }
     assert_equal aug.error[:details], "Can not find lens bad_lens"
   end
 
   def test_transform
-    aug = aug_create(Augeas::NO_LOAD)
+    aug = aug_create(:no_load => true)
     aug.clear_transforms
     aug.transform(:lens => "Hosts.lns",
                   :incl => "/etc/hosts")
@@ -204,7 +204,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_defvar
-    Augeas::open("/dev/null") do |aug|
+    Augeas::create(:root => "/dev/null") do |aug|
       aug.set("/a/b", "bval")
       aug.set("/a/c", "cval")
       assert aug.defvar("var", "/a/b")
@@ -278,7 +278,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_save_tree_error
-    aug = aug_create(Augeas::NO_LOAD)
+    aug = aug_create(:no_load => true)
     aug.set("/files/etc/sysconfig/iptables", "bad")
     assert_raises(Augeas::CommandExecutionError) {aug.save}
     assert aug.get("/augeas/files/etc/sysconfig/iptables/error")
@@ -374,7 +374,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_defvar
-    Augeas::open("/dev/null") do |aug|
+    Augeas::create(:root => "/dev/null") do |aug|
       aug.set("/a/b", "bval")
       aug.set("/a/c", "cval")
       assert aug.defvar("var", "/a/b")
@@ -425,15 +425,35 @@ class TestAugeas < Test::Unit::TestCase
     assert_raises(Augeas::NoMatchError) { aug.span("bogus") }
   end
 
+  def test_flag_save_noop
+    aug = aug_create(:save_noop => true)
+    assert_equal("noop", aug.get("/augeas/save"))
+  end
+
+  def test_flag_no_load
+    aug = aug_create(:no_load => true)
+    assert_equal([], aug.match("/files/*"))
+  end
+
+  def test_flag_no_modl_autoload
+    aug = aug_create(:no_modl_autoload => true)
+    assert_equal([], aug.match("/files/*"))
+  end
+
+  def test_flag_enable_span
+    aug = aug_create(:enable_span => true)
+    assert_equal("enable", aug.get("/augeas/span"))
+  end
+
   private
 
-  def aug_create(flags = Augeas::NONE)
+  def aug_create(flags={})
     if File::directory?(TST_ROOT)
       FileUtils::rm_rf(TST_ROOT)
     end
     FileUtils::mkdir_p(TST_ROOT)
     FileUtils::cp_r(SRC_ROOT, TST_ROOT)
 
-    Augeas::create(:root => TST_ROOT, :loadpath => nil, :flags => flags)
+    Augeas::create({:root => TST_ROOT, :loadpath => nil}.merge(flags))
   end
 end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -38,7 +38,7 @@ class TestAugeas < Test::Unit::TestCase
   TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
 
   def test_basics
-    aug = aug_open(Augeas::SAVE_NEWFILE)
+    aug = aug_create(Augeas::SAVE_NEWFILE)
     assert_equal("newfile", aug.get("/augeas/save"))
     assert_equal(TST_ROOT, aug.get("/augeas/root"))
 
@@ -98,36 +98,36 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_mv_descendent_error
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo", "bar")
     assert_raises(Augeas::DescendantError) {aug.mv("/foo", "/foo/bar/baz")}
   end
 
   def test_mv_multiple_matches_error
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo/bar", "bar")
     aug.set("/foo/baz", "baz")
     assert_raises(Augeas::MultipleMatchesError) {aug.mv("/foo/*", "/qux")}
   end
 
   def test_mv_invalid_path_error
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) {aug.mv("/foo", "[]")}
   end
 
   def test_mv_no_match_error
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::NoMatchError) {aug.mv("/nonexistent", "/")}
   end
 
   def test_mv_mutiple_dest_error
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo", "bar")
     assert_raises(Augeas::CommandExecutionError) {aug.mv("/foo", "/bar/baz/*")}
   end
 
   def test_load
-    aug = aug_open(Augeas::NO_LOAD)
+    aug = aug_create(Augeas::NO_LOAD)
     assert_equal([], aug.match("/files/etc/*"))
     aug.rm("/augeas/load/*");
     assert_nothing_raised {
@@ -137,14 +137,14 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_load_bad_lens
-    aug = aug_open(Augeas::NO_LOAD)
+    aug = aug_create(Augeas::NO_LOAD)
     aug.transform(:lens => "bad_lens", :incl => "irrelevant")
     assert_raises(Augeas::LensNotFoundError) { aug.load }
     assert_equal aug.error[:details], "Can not find lens bad_lens"
   end
 
   def test_transform
-    aug = aug_open(Augeas::NO_LOAD)
+    aug = aug_create(Augeas::NO_LOAD)
     aug.clear_transforms
     aug.transform(:lens => "Hosts.lns",
                   :incl => "/etc/hosts")
@@ -171,27 +171,27 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_transform_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::InvalidPathError) {
       aug.transform :lens => '//', :incl => 'foo' }
   end
 
   def test_clear_transforms
-    aug = aug_open
+    aug = aug_create
     assert_not_equal [], aug.match("/augeas/load/*")
     aug.clear_transforms
     assert_equal [], aug.match("/augeas/load/*")
   end
 
   def test_clear
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo/bar", "baz")
     aug.clear("/foo/bar")
     assert_equal aug.get("/foo/bar"), nil
   end
 
   def test_rm
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo/bar", "baz")
     assert aug.get("/foo/bar")
     assert_equal 2, aug.rm("/foo")
@@ -199,7 +199,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_rm_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) { aug.rm('//') }
   end
 
@@ -218,42 +218,42 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_defnode
-    aug = aug_open
+    aug = aug_create
     assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
     assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
   end
 
   def test_insert_before
-    aug = aug_open
+    aug = aug_create
     aug.set("/parent/child", "foo")
     aug.insert("/parent/child", "sibling", true)
     assert_equal ["/parent/sibling", "/parent/child"], aug.match("/parent/*")
   end
 
   def test_insert_after
-    aug = aug_open
+    aug = aug_create
     aug.set("/parent/child", "foo")
     aug.insert("/parent/child", "sibling", false)
     assert_equal ["/parent/child", "/parent/sibling"], aug.match("/parent/*")
   end
 
   def test_insert_no_match
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::NoMatchError) { aug.insert "foo", "bar", "baz" }
   end
 
   def test_insert_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::InvalidPathError) { aug.insert "//", "bar", "baz" }
   end
 
   def test_insert_too_many_matches
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::MultipleMatchesError) { aug.insert "/*", "a", "b" }
   end
 
   def test_match
-    aug = aug_open
+    aug = aug_create
     aug.set("/foo/bar", "baz")
     aug.set("/foo/baz", "qux")
     aug.set("/foo/qux", "bar")
@@ -262,23 +262,23 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_match_empty_list
-    aug = aug_open
+    aug = aug_create
     assert_equal([], aug.match("/nonexistent"))
   end
 
   def test_match_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) { aug.match('//') }
   end
 
   def test_save
-    aug = aug_open
+    aug = aug_create
     aug.set("/files/etc/hosts/1/garbage", "trash")
     assert_raises(Augeas::CommandExecutionError) { aug.save }
   end
 
   def test_save_tree_error
-    aug = aug_open(Augeas::NO_LOAD)
+    aug = aug_create(Augeas::NO_LOAD)
     aug.set("/files/etc/sysconfig/iptables", "bad")
     assert_raises(Augeas::CommandExecutionError) {aug.save}
     assert aug.get("/augeas/files/etc/sysconfig/iptables/error")
@@ -287,17 +287,17 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_set_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) { aug.set("files/etc//", nil) }
   end
 
   def test_set_multiple_matches_error
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::MultipleMatchesError) { aug.set("files/etc/*", nil) }
   end
 
   def test_set
-    aug = aug_open
+    aug = aug_create
     aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
     assert_equal(aug.get("/files/etc/group/disk/user[1]"), "root")
     assert_equal(aug.get("/files/etc/group/disk/user[2]"), "user1")
@@ -319,7 +319,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_setm
-    aug = aug_open
+    aug = aug_create
 
     aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]",
              "users", "testuser1")
@@ -333,24 +333,24 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_setm_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::InvalidPathError) { aug.setm("[]", "bar", "baz") }
   end
 
   def test_exists
-    aug = aug_open
+    aug = aug_create
     assert_equal false, aug.exists("/foo")
     aug.set("/foo", "bar")
     assert aug.exists("/foo")
   end
 
   def test_exists_invalid_path_error
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) {aug.exists("[]")}
   end
   
   def test_get_multiple_matches_error
-    aug = aug_open
+    aug = aug_create
 
     # Cause an error
     assert_raises (Augeas::MultipleMatchesError) { 
@@ -364,7 +364,7 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_get_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::InvalidPathError) { aug.get("//") }
 
     err = aug.error
@@ -384,23 +384,23 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_defvar_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::InvalidPathError) { aug.defvar('var', 'F#@!$#@') }
   end
 
   def test_defnode
-    aug = aug_open
+    aug = aug_create
     assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
     assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
   end
 
   def test_defnode_invalid_path
-    aug = aug_open
+    aug = aug_create
     assert_raises (Augeas::InvalidPathError) { aug.defnode('x', '//', nil)}
   end
 
   def test_span
-    aug = aug_open
+    aug = aug_create
 
     aug.set("/augeas/span", "enable")
     aug.rm("/files/etc")
@@ -414,20 +414,20 @@ class TestAugeas < Test::Unit::TestCase
   end
 
   def test_span_no_span_info
-    aug = aug_open
+    aug = aug_create
     # this error should be raised because we haven't enabled the span
     assert_raises(Augeas::NoSpanInfoError) {
       aug.span("/files/etc/ssh/sshd_config/Protocol") }
   end
 
   def test_span_no_matches
-    aug = aug_open
+    aug = aug_create
     assert_raises(Augeas::NoMatchError) { aug.span("bogus") }
   end
 
   private
 
-  def aug_open(flags = Augeas::NONE)
+  def aug_create(flags = Augeas::NONE)
     if File::directory?(TST_ROOT)
       FileUtils::rm_rf(TST_ROOT)
     end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -165,10 +165,19 @@ class TestAugeas < Test::Unit::TestCase
     assert_raises(Augeas::InvalidPathError) { aug.match('//') }
   end
 
-  def test_save!
+  def test_save
     aug = aug_open
     aug.set("/files/etc/hosts/1/garbage", "trash")
-    assert_raises(Augeas::Error) { aug.save! }
+    assert_raises(Augeas::CommandExecutionError) { aug.save }
+  end
+
+  def test_save_tree_error
+    aug = aug_open(Augeas::NO_LOAD)
+    aug.set("/files/etc/sysconfig/iptables", "bad")
+    assert_raises(Augeas::CommandExecutionError) {aug.save}
+    assert aug.get("/augeas/files/etc/sysconfig/iptables/error")
+    assert_equal("No such file or directory",
+                 aug.get("/augeas/files/etc/sysconfig/iptables/error/message"))
   end
 
   def test_set!

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -104,6 +104,19 @@ class TestAugeas < Test::Unit::TestCase
                      aug.match("/files/etc/*").sort)
     end
 
+    def test_rm
+      aug = aug_open
+      aug.set("/foo/bar", "baz")
+      assert aug.get("/foo/bar")
+      assert_equal 2, aug.rm("/foo")
+      assert_nil aug.get("/foo")
+    end
+
+    def test_rm_invalid_path
+      aug = aug_open
+      assert_raises(Augeas::InvalidPathError) { aug.rm('//') }
+    end
+
     def test_defvar
         Augeas::open("/dev/null") do |aug|
             aug.set("/a/b", "bval")
@@ -181,6 +194,30 @@ class TestAugeas < Test::Unit::TestCase
         assert err[:minor].nil?
     end
 
+    def test_get_multiple_matches_error
+        aug = aug_open
+
+        # Cause an error
+        assert_raises (Augeas::MultipleMatchesError) { 
+            aug.get("/files/etc/hosts/*") }
+        
+        err = aug.error
+        assert_equal(Augeas::EMMATCH, err[:code])
+        assert err[:message]
+        assert err[:details]
+        assert err[:minor].nil?
+    end
+
+    def test_get_invalid_path
+        aug = aug_open
+        assert_raises (Augeas::InvalidPathError) { aug.get("//") }
+
+        err = aug.error
+        assert_equal(Augeas::EPATHX, err[:code])
+        assert err[:message]
+        assert err[:details]
+    end
+
     def test_span
         aug = aug_open
 
@@ -206,6 +243,6 @@ class TestAugeas < Test::Unit::TestCase
         FileUtils::mkdir_p(TST_ROOT)
         FileUtils::cp_r(SRC_ROOT, TST_ROOT)
 
-        Augeas::open(TST_ROOT, nil, flags)
+        Augeas::create(TST_ROOT, nil, flags)
     end
 end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -13,236 +13,238 @@ require 'fileutils'
 
 class TestAugeas < Test::Unit::TestCase
 
-    SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
-    TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
+  SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
+  TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
 
-    def test_basics
-        aug = aug_open(Augeas::SAVE_NEWFILE)
-        assert_equal("newfile", aug.get("/augeas/save"))
-        assert_equal(TST_ROOT, aug.get("/augeas/root"))
+  def test_basics
+    aug = aug_open(Augeas::SAVE_NEWFILE)
+    assert_equal("newfile", aug.get("/augeas/save"))
+    assert_equal(TST_ROOT, aug.get("/augeas/root"))
 
-        assert(aug.exists("/augeas/root"))
-        assert_not_nil(aug.get("/augeas/root"))
-        node = "/ruby/test/node"
-        assert_nothing_raised {
-            aug.set(node, "value")
-        }
-        assert_equal("value", aug.get(node))
-        assert_nothing_raised {
-            aug.clear(node)
-        }
-        assert_equal(nil, aug.get(node))
-        m = aug.match("/*")
-        ["/augeas", "/ruby"].each do |p|
-            assert(m.include?(p))
-            assert(aug.exists(p))
-        end
+    assert(aug.exists("/augeas/root"))
+    assert_not_nil(aug.get("/augeas/root"))
+    node = "/ruby/test/node"
+    assert_nothing_raised {
+      aug.set(node, "value")
+    }
+    assert_equal("value", aug.get(node))
+    assert_nothing_raised {
+      aug.clear(node)
+    }
+    assert_equal(nil, aug.get(node))
+    m = aug.match("/*")
+    ["/augeas", "/ruby"].each do |p|
+      assert(m.include?(p))
+      assert(aug.exists(p))
     end
+  end
 
-    def test_no_new
-        assert_raise NoMethodError do
-            Augeas.new
-        end
+  def test_no_new
+    assert_raise NoMethodError do
+      Augeas.new
     end
+  end
 
-    def test_close
-        aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
-        assert_equal("newfile", aug.get("/augeas/save"))
-        aug.close
+  def test_close
+    aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
+    assert_equal("newfile", aug.get("/augeas/save"))
+    aug.close
 
-        assert_raise(SystemCallError) {
-            aug.get("/augeas/save")
-        }
+    assert_raise(SystemCallError) {
+      aug.get("/augeas/save")
+    }
 
-        assert_raise(SystemCallError) {
-            aug.close
-        }
+    assert_raise(SystemCallError) {
+      aug.close
+    }
+  end
+
+  def test_mv
+    Augeas::open("/dev/null") do |aug|
+      aug.set("/a/b", "value")
+      aug.mv("/a/b", "/x/y")
+      assert_equal("value", aug.get("/x/y"))
     end
+  end
 
-    def test_mv
-        Augeas::open("/dev/null") do |aug|
-            aug.set("/a/b", "value")
-            aug.mv("/a/b", "/x/y")
-            assert_equal("value", aug.get("/x/y"))
-        end
+  def test_load
+    aug = aug_open(Augeas::NO_LOAD)
+    assert_equal([], aug.match("/files/etc/*"))
+    aug.rm("/augeas/load/*");
+    assert_nothing_raised {
+      aug.load
+    }
+    assert_equal([], aug.match("/files/etc/*"))
+  end
+
+  def test_transform
+    aug = aug_open(Augeas::NO_LOAD)
+    aug.clear_transforms
+    aug.transform(:lens => "Hosts.lns",
+                  :incl => "/etc/hosts")
+    assert_raise(ArgumentError) {
+      aug.transform(:name => "Fstab",
+                    :incl => [ "/etc/fstab" ],
+                    :excl => [ "*~", "*.rpmnew" ])
+    }
+    aug.transform(:lens => "Inittab.lns",
+                  :incl => "/etc/inittab")
+    aug.transform(:lens => "Fstab.lns",
+                  :incl => "/etc/fstab*",
+                  :excl => "*~")
+    assert_equal(["/augeas/load/Fstab", "/augeas/load/Fstab/excl",
+                  "/augeas/load/Fstab/incl", "/augeas/load/Fstab/lens",
+                  "/augeas/load/Hosts", "/augeas/load/Hosts/incl",
+                  "/augeas/load/Hosts/lens", "/augeas/load/Inittab",
+                  "/augeas/load/Inittab/incl",
+                  "/augeas/load/Inittab/lens"],
+                 aug.match("/augeas/load//*").sort)
+    aug.load
+    assert_equal(["/files/etc/hosts", "/files/etc/inittab"],
+                 aug.match("/files/etc/*").sort)
+  end
+
+  def test_rm
+    aug = aug_open
+    aug.set("/foo/bar", "baz")
+    assert aug.get("/foo/bar")
+    assert_equal 2, aug.rm("/foo")
+    assert_nil aug.get("/foo")
+  end
+
+  def test_rm_invalid_path
+    aug = aug_open
+    assert_raises(Augeas::InvalidPathError) { aug.rm('//') }
+  end
+
+  def test_defvar
+    Augeas::open("/dev/null") do |aug|
+      aug.set("/a/b", "bval")
+      aug.set("/a/c", "cval")
+      assert aug.defvar("var", "/a/b")
+      assert_equal(["/a/b"], aug.match("$var"))
+      assert aug.defvar("var", nil)
+      assert_raises(SystemCallError) {
+        aug.match("$var")
+      }
+      assert ! aug.defvar("var", "/foo/")
     end
+  end
 
-    def test_load
-        aug = aug_open(Augeas::NO_LOAD)
-        assert_equal([], aug.match("/files/etc/*"))
-        aug.rm("/augeas/load/*");
-        assert_nothing_raised {
-            aug.load
-        }
-        assert_equal([], aug.match("/files/etc/*"))
+  def test_defnode
+    aug = aug_open
+    assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
+    assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
+  end
+
+  def test_save!
+    aug = aug_open
+    aug.set("/files/etc/hosts/1/garbage", "trash")
+    assert_raises(Augeas::Error) { aug.save! }
+  end
+
+  def test_set!
+    aug = aug_open
+    assert_raises(Augeas::Error) { aug.set!("files/etc/hosts/*", nil) }
+  end
+
+  def test_set
+    aug = aug_open
+    aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
+    assert_equal(aug.get("/files/etc/group/disk/user[1]"), "root")
+    assert_equal(aug.get("/files/etc/group/disk/user[2]"), "user1")
+    assert_equal(aug.get("/files/etc/group/disk/user[3]"), "user2")
+
+    aug.set("/files/etc/group/new_group/user[last()+1]",
+            "nuser1",["nuser2","nuser3"])
+    assert_equal(aug.get("/files/etc/group/new_group/user[1]"), "nuser1")
+    assert_equal(aug.get("/files/etc/group/new_group/user[2]"), "nuser2")
+    assert_equal(aug.get("/files/etc/group/new_group/user[3]"), "nuser3")
+
+    aug.rm("/files/etc/group/disk/user")
+    aug.set("/files/etc/group/disk/user[last()+1]", "testuser")
+    assert_equal(aug.get("/files/etc/group/disk/user"), "testuser")
+
+    aug.rm("/files/etc/group/disk/user")
+    aug.set("/files/etc/group/disk/user[last()+1]", nil)
+    assert_equal(aug.get("/files/etc/group/disk/user"), nil)
+  end
+
+  def test_setm
+    aug = aug_open
+
+    aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]",
+             "users", "testuser1")
+    assert_equal(aug.get("/files/etc/group/rpc/users"), "testuser1")
+    assert_equal(aug.get("/files/etc/group/rpcuser/users"), "testuser1")
+
+    aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]/users",
+             nil, "testuser2")
+    assert_equal(aug.get("/files/etc/group/rpc/users"), "testuser2")
+    assert_equal(aug.get("/files/etc/group/rpcuser/users"), "testuser2")
+  end
+
+  def test_error
+    aug = aug_open
+
+    # Cause an error
+    aug.get("/files/etc/hosts/*")
+    err = aug.error
+    assert_equal(Augeas::EMMATCH, err[:code])
+    assert err[:message]
+    assert err[:details]
+    assert err[:minor].nil?
+  end
+
+  def test_get_multiple_matches_error
+    aug = aug_open
+
+    # Cause an error
+    assert_raises (Augeas::MultipleMatchesError) { 
+      aug.get("/files/etc/hosts/*") }
+    
+    err = aug.error
+    assert_equal(Augeas::EMMATCH, err[:code])
+    assert err[:message]
+    assert err[:details]
+    assert err[:minor].nil?
+  end
+
+  def test_get_invalid_path
+    aug = aug_open
+    assert_raises (Augeas::InvalidPathError) { aug.get("//") }
+
+    err = aug.error
+    assert_equal(Augeas::EPATHX, err[:code])
+    assert err[:message]
+    assert err[:details]
+  end
+
+  def test_span
+    aug = aug_open
+
+    span = aug.span("/files/etc/ssh/sshd_config/Protocol")
+    assert_equal({}, span)
+
+    aug.set("/augeas/span", "enable")
+    aug.rm("/files/etc")
+    aug.load
+
+    span = aug.span("/files/etc/ssh/sshd_config/Protocol")
+    assert_not_nil(span[:filename])
+    assert_equal(29..37, span[:label])
+    assert_equal(38..39, span[:value])
+    assert_equal(29..40, span[:span])
+  end
+
+  private
+  def aug_open(flags = Augeas::NONE)
+    if File::directory?(TST_ROOT)
+      FileUtils::rm_rf(TST_ROOT)
     end
+    FileUtils::mkdir_p(TST_ROOT)
+    FileUtils::cp_r(SRC_ROOT, TST_ROOT)
 
-    def test_transform
-        aug = aug_open(Augeas::NO_LOAD)
-        aug.clear_transforms
-        aug.transform(:lens => "Hosts.lns",
-                      :incl => "/etc/hosts")
-        assert_raise(ArgumentError) {
-            aug.transform(:name => "Fstab",
-                          :incl => [ "/etc/fstab" ],
-                          :excl => [ "*~", "*.rpmnew" ])
-        }
-        aug.transform(:lens => "Inittab.lns",
-                      :incl => "/etc/inittab")
-        aug.transform(:lens => "Fstab.lns",
-                      :incl => "/etc/fstab*",
-                      :excl => "*~")
-        assert_equal(["/augeas/load/Fstab", "/augeas/load/Fstab/excl",
-                      "/augeas/load/Fstab/incl", "/augeas/load/Fstab/lens",
-                      "/augeas/load/Hosts", "/augeas/load/Hosts/incl",
-                      "/augeas/load/Hosts/lens", "/augeas/load/Inittab",
-                      "/augeas/load/Inittab/incl",
-                      "/augeas/load/Inittab/lens"],
-                     aug.match("/augeas/load//*").sort)
-        aug.load
-        assert_equal(["/files/etc/hosts", "/files/etc/inittab"],
-                     aug.match("/files/etc/*").sort)
-    end
-
-    def test_rm
-      aug = aug_open
-      aug.set("/foo/bar", "baz")
-      assert aug.get("/foo/bar")
-      assert_equal 2, aug.rm("/foo")
-      assert_nil aug.get("/foo")
-    end
-
-    def test_rm_invalid_path
-      aug = aug_open
-      assert_raises(Augeas::InvalidPathError) { aug.rm('//') }
-    end
-
-    def test_defvar
-        Augeas::open("/dev/null") do |aug|
-            aug.set("/a/b", "bval")
-            aug.set("/a/c", "cval")
-            assert aug.defvar("var", "/a/b")
-            assert_equal(["/a/b"], aug.match("$var"))
-            assert aug.defvar("var", nil)
-            assert_raises(SystemCallError) {
-                aug.match("$var")
-            }
-            assert ! aug.defvar("var", "/foo/")
-        end
-    end
-
-    def test_defnode
-        aug = aug_open
-        assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
-        assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
-    end
-
-    def test_save!
-        aug = aug_open
-        aug.set("/files/etc/hosts/1/garbage", "trash")
-        assert_raises(Augeas::Error) { aug.save! }
-    end
-
-    def test_set!
-        aug = aug_open
-        assert_raises(Augeas::Error) { aug.set!("files/etc/hosts/*", nil) }
-    end
-
-    def test_set
-       aug = aug_open
-       aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
-       assert_equal( aug.get("/files/etc/group/disk/user[1]"),"root" )
-       assert_equal( aug.get("/files/etc/group/disk/user[2]"),"user1" )
-       assert_equal( aug.get("/files/etc/group/disk/user[3]"),"user2" )
-
-       aug.set("/files/etc/group/new_group/user[last()+1]",
-	       "nuser1",["nuser2","nuser3"])
-       assert_equal( aug.get("/files/etc/group/new_group/user[1]"),"nuser1")
-       assert_equal( aug.get("/files/etc/group/new_group/user[2]"),"nuser2" )
-       assert_equal( aug.get("/files/etc/group/new_group/user[3]"),"nuser3" )
-
-       aug.rm("/files/etc/group/disk/user")
-       aug.set("/files/etc/group/disk/user[last()+1]","testuser")
-       assert_equal( aug.get("/files/etc/group/disk/user"),"testuser")
-
-       aug.rm("/files/etc/group/disk/user")
-       aug.set("/files/etc/group/disk/user[last()+1]", nil)
-       assert_equal( aug.get("/files/etc/group/disk/user"), nil)
-    end
-
-    def test_setm
-        aug = aug_open
-
-        aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]","users", "testuser1")
-        assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser1")
-        assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser1")
-
-        aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]/users",nil, "testuser2")
-        assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser2")
-        assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser2")
-    end
-
-    def test_error
-        aug = aug_open
-
-        # Cause an error
-        aug.get("/files/etc/hosts/*")
-        err = aug.error
-        assert_equal(Augeas::EMMATCH, err[:code])
-        assert err[:message]
-        assert err[:details]
-        assert err[:minor].nil?
-    end
-
-    def test_get_multiple_matches_error
-        aug = aug_open
-
-        # Cause an error
-        assert_raises (Augeas::MultipleMatchesError) { 
-            aug.get("/files/etc/hosts/*") }
-        
-        err = aug.error
-        assert_equal(Augeas::EMMATCH, err[:code])
-        assert err[:message]
-        assert err[:details]
-        assert err[:minor].nil?
-    end
-
-    def test_get_invalid_path
-        aug = aug_open
-        assert_raises (Augeas::InvalidPathError) { aug.get("//") }
-
-        err = aug.error
-        assert_equal(Augeas::EPATHX, err[:code])
-        assert err[:message]
-        assert err[:details]
-    end
-
-    def test_span
-        aug = aug_open
-
-        span = aug.span("/files/etc/ssh/sshd_config/Protocol")
-        assert_equal({}, span)
-
-        aug.set("/augeas/span", "enable")
-        aug.rm("/files/etc")
-        aug.load
-
-        span = aug.span("/files/etc/ssh/sshd_config/Protocol")
-        assert_not_nil(span[:filename])
-        assert_equal(29..37, span[:label])
-        assert_equal(38..39, span[:value])
-        assert_equal(29..40, span[:span])
-    end
-
-    private
-    def aug_open(flags = Augeas::NONE)
-        if File::directory?(TST_ROOT)
-            FileUtils::rm_rf(TST_ROOT)
-        end
-        FileUtils::mkdir_p(TST_ROOT)
-        FileUtils::cp_r(SRC_ROOT, TST_ROOT)
-
-        Augeas::create(TST_ROOT, nil, flags)
-    end
+    Augeas::create(TST_ROOT, nil, flags)
+  end
 end

--- a/tests/tc_augeas_old.rb
+++ b/tests/tc_augeas_old.rb
@@ -1,5 +1,27 @@
-# These tests are run against the old deprecated module which is
-# instantiated by Augeas::open
+##
+#  These tests are run against the old deprecated module which is
+#  instantiated by Augeas::open
+#
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#  Copyright (C) 2011 Red Hat Inc.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+# Authors: David Lutterkort <dlutter@redhat.com>
+#          Ionuț Arțăriși <iartarisi@suse.cz>
+##
 
 require 'test/unit'
 

--- a/tests/tc_augeas_old.rb
+++ b/tests/tc_augeas_old.rb
@@ -13,208 +13,208 @@ require 'fileutils'
 
 class TestAugeasOld < Test::Unit::TestCase
 
-    SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
-    TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
+  SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
+  TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
 
-    def test_basics
-        aug = aug_open(Augeas::SAVE_NEWFILE)
-        assert_equal("newfile", aug.get("/augeas/save"))
-        assert_equal(TST_ROOT, aug.get("/augeas/root"))
+  def test_basics
+    aug = aug_open(Augeas::SAVE_NEWFILE)
+    assert_equal("newfile", aug.get("/augeas/save"))
+    assert_equal(TST_ROOT, aug.get("/augeas/root"))
 
-        assert(aug.exists("/augeas/root"))
-        assert_not_nil(aug.get("/augeas/root"))
-        node = "/ruby/test/node"
-        assert_nothing_raised {
-            aug.set(node, "value")
-        }
-        assert_equal("value", aug.get(node))
-        assert_nothing_raised {
-            aug.clear(node)
-        }
-        assert_equal(nil, aug.get(node))
-        m = aug.match("/*")
-        ["/augeas", "/ruby"].each do |p|
-            assert(m.include?(p))
-            assert(aug.exists(p))
-        end
+    assert(aug.exists("/augeas/root"))
+    assert_not_nil(aug.get("/augeas/root"))
+    node = "/ruby/test/node"
+    assert_nothing_raised {
+      aug.set(node, "value")
+    }
+    assert_equal("value", aug.get(node))
+    assert_nothing_raised {
+      aug.clear(node)
+    }
+    assert_equal(nil, aug.get(node))
+    m = aug.match("/*")
+    ["/augeas", "/ruby"].each do |p|
+      assert(m.include?(p))
+      assert(aug.exists(p))
     end
+  end
 
-    def test_no_new
-        assert_raise NoMethodError do
-            Augeas.new
-        end
+  def test_no_new
+    assert_raise NoMethodError do
+      Augeas.new
     end
+  end
 
-    def test_open_block
-        foo = nil
-        Augeas::open do |aug|
-            aug.set('/foo', 'bar')
-            foo = aug.get('/foo')
-        end
-        assert_equal(foo, 'bar')
+  def test_open_block
+    foo = nil
+    Augeas::open do |aug|
+      aug.set('/foo', 'bar')
+      foo = aug.get('/foo')
     end
+    assert_equal(foo, 'bar')
+  end
 
-    def test_close
-        aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
-        assert_equal("newfile", aug.get("/augeas/save"))
-        aug.close
+  def test_close
+    aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
+    assert_equal("newfile", aug.get("/augeas/save"))
+    aug.close
 
-        assert_raise(SystemCallError) {
-            aug.get("/augeas/save")
-        }
+    assert_raise(SystemCallError) {
+      aug.get("/augeas/save")
+    }
 
-        assert_raise(SystemCallError) {
-            aug.close
-        }
+    assert_raise(SystemCallError) {
+      aug.close
+    }
+  end
+
+  def test_mv
+    Augeas::open("/dev/null") do |aug|
+      aug.set("/a/b", "value")
+      aug.mv("/a/b", "/x/y")
+      assert_equal("value", aug.get("/x/y"))
     end
+  end
 
-    def test_mv
-        Augeas::open("/dev/null") do |aug|
-            aug.set("/a/b", "value")
-            aug.mv("/a/b", "/x/y")
-            assert_equal("value", aug.get("/x/y"))
-        end
+  def test_load
+    aug = aug_open(Augeas::NO_LOAD)
+    assert_equal([], aug.match("/files/etc/*"))
+    aug.rm("/augeas/load/*");
+    assert_nothing_raised {
+      aug.load
+    }
+    assert_equal([], aug.match("/files/etc/*"))
+  end
+
+  def test_transform
+    aug = aug_open(Augeas::NO_LOAD)
+    aug.clear_transforms
+    aug.transform(:lens => "Hosts.lns",
+                  :incl => "/etc/hosts")
+    assert_raise(ArgumentError) {
+      aug.transform(:name => "Fstab",
+                    :incl => [ "/etc/fstab" ],
+                    :excl => [ "*~", "*.rpmnew" ])
+    }
+    aug.transform(:lens => "Inittab.lns",
+                  :incl => "/etc/inittab")
+    aug.transform(:lens => "Fstab.lns",
+                  :incl => "/etc/fstab*",
+                  :excl => "*~")
+    assert_equal(["/augeas/load/Fstab", "/augeas/load/Fstab/excl",
+                  "/augeas/load/Fstab/incl", "/augeas/load/Fstab/lens",
+                  "/augeas/load/Hosts", "/augeas/load/Hosts/incl",
+                  "/augeas/load/Hosts/lens", "/augeas/load/Inittab",
+                  "/augeas/load/Inittab/incl",
+                  "/augeas/load/Inittab/lens"],
+                 aug.match("/augeas/load//*").sort)
+    aug.load
+    assert_equal(["/files/etc/hosts", "/files/etc/inittab"],
+                 aug.match("/files/etc/*").sort)
+  end
+
+  def test_defvar
+    Augeas::open("/dev/null") do |aug|
+      aug.set("/a/b", "bval")
+      aug.set("/a/c", "cval")
+      assert aug.defvar("var", "/a/b")
+      assert_equal(["/a/b"], aug.match("$var"))
+      assert aug.defvar("var", nil)
+      assert_raises(SystemCallError) {
+        aug.match("$var")
+      }
+      assert ! aug.defvar("var", "/foo/")
     end
+  end
 
-    def test_load
-        aug = aug_open(Augeas::NO_LOAD)
-        assert_equal([], aug.match("/files/etc/*"))
-        aug.rm("/augeas/load/*");
-        assert_nothing_raised {
-            aug.load
-        }
-        assert_equal([], aug.match("/files/etc/*"))
+  def test_defnode
+    aug = aug_open
+    assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
+    assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
+  end
+
+  def test_save!
+    aug = aug_open
+    aug.set("/files/etc/hosts/1/garbage", "trash")
+    assert_raises(Augeas::Error) { aug.save! }
+  end
+
+  def test_set!
+    aug = aug_open
+    assert_raises(Augeas::Error) { aug.set!("files/etc/hosts/*", nil) }
+  end
+
+  def test_set
+    aug = aug_open
+    aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
+    assert_equal( aug.get("/files/etc/group/disk/user[1]"),"root" )
+    assert_equal( aug.get("/files/etc/group/disk/user[2]"),"user1" )
+    assert_equal( aug.get("/files/etc/group/disk/user[3]"),"user2" )
+
+    aug.set("/files/etc/group/new_group/user[last()+1]",
+            "nuser1",["nuser2","nuser3"])
+    assert_equal( aug.get("/files/etc/group/new_group/user[1]"),"nuser1")
+    assert_equal( aug.get("/files/etc/group/new_group/user[2]"),"nuser2" )
+    assert_equal( aug.get("/files/etc/group/new_group/user[3]"),"nuser3" )
+
+    aug.rm("/files/etc/group/disk/user")
+    aug.set("/files/etc/group/disk/user[last()+1]","testuser")
+    assert_equal( aug.get("/files/etc/group/disk/user"),"testuser")
+
+    aug.rm("/files/etc/group/disk/user")
+    aug.set("/files/etc/group/disk/user[last()+1]", nil)
+    assert_equal( aug.get("/files/etc/group/disk/user"), nil)
+  end
+
+  def test_setm
+    aug = aug_open
+
+    aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]","users", "testuser1")
+    assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser1")
+    assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser1")
+
+    aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]/users",nil, "testuser2")
+    assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser2")
+    assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser2")
+  end
+
+  def test_error
+    aug = aug_open
+
+    # Cause an error
+    aug.get("/files/etc/hosts/*")
+    err = aug.error
+    assert_equal(Augeas::EMMATCH, err[:code])
+    assert err[:message]
+    assert err[:details]
+    assert err[:minor].nil?
+  end
+
+  def test_span
+    aug = aug_open
+
+    span = aug.span("/files/etc/ssh/sshd_config/Protocol")
+    assert_equal({}, span)
+
+    aug.set("/augeas/span", "enable")
+    aug.rm("/files/etc")
+    aug.load
+
+    span = aug.span("/files/etc/ssh/sshd_config/Protocol")
+    assert_not_nil(span[:filename])
+    assert_equal(29..37, span[:label])
+    assert_equal(38..39, span[:value])
+    assert_equal(29..40, span[:span])
+  end
+
+  private
+  def aug_open(flags = Augeas::NONE)
+    if File::directory?(TST_ROOT)
+      FileUtils::rm_rf(TST_ROOT)
     end
+    FileUtils::mkdir_p(TST_ROOT)
+    FileUtils::cp_r(SRC_ROOT, TST_ROOT)
 
-    def test_transform
-        aug = aug_open(Augeas::NO_LOAD)
-        aug.clear_transforms
-        aug.transform(:lens => "Hosts.lns",
-                      :incl => "/etc/hosts")
-        assert_raise(ArgumentError) {
-            aug.transform(:name => "Fstab",
-                          :incl => [ "/etc/fstab" ],
-                          :excl => [ "*~", "*.rpmnew" ])
-        }
-        aug.transform(:lens => "Inittab.lns",
-                      :incl => "/etc/inittab")
-        aug.transform(:lens => "Fstab.lns",
-                      :incl => "/etc/fstab*",
-                      :excl => "*~")
-        assert_equal(["/augeas/load/Fstab", "/augeas/load/Fstab/excl",
-                      "/augeas/load/Fstab/incl", "/augeas/load/Fstab/lens",
-                      "/augeas/load/Hosts", "/augeas/load/Hosts/incl",
-                      "/augeas/load/Hosts/lens", "/augeas/load/Inittab",
-                      "/augeas/load/Inittab/incl",
-                      "/augeas/load/Inittab/lens"],
-                     aug.match("/augeas/load//*").sort)
-        aug.load
-        assert_equal(["/files/etc/hosts", "/files/etc/inittab"],
-                     aug.match("/files/etc/*").sort)
-    end
-
-    def test_defvar
-        Augeas::open("/dev/null") do |aug|
-            aug.set("/a/b", "bval")
-            aug.set("/a/c", "cval")
-            assert aug.defvar("var", "/a/b")
-            assert_equal(["/a/b"], aug.match("$var"))
-            assert aug.defvar("var", nil)
-            assert_raises(SystemCallError) {
-                aug.match("$var")
-            }
-            assert ! aug.defvar("var", "/foo/")
-        end
-    end
-
-    def test_defnode
-        aug = aug_open
-        assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
-        assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
-    end
-
-    def test_save!
-        aug = aug_open
-        aug.set("/files/etc/hosts/1/garbage", "trash")
-        assert_raises(Augeas::Error) { aug.save! }
-    end
-
-    def test_set!
-        aug = aug_open
-        assert_raises(Augeas::Error) { aug.set!("files/etc/hosts/*", nil) }
-    end
-
-    def test_set
-       aug = aug_open
-       aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
-       assert_equal( aug.get("/files/etc/group/disk/user[1]"),"root" )
-       assert_equal( aug.get("/files/etc/group/disk/user[2]"),"user1" )
-       assert_equal( aug.get("/files/etc/group/disk/user[3]"),"user2" )
-
-       aug.set("/files/etc/group/new_group/user[last()+1]",
-	       "nuser1",["nuser2","nuser3"])
-       assert_equal( aug.get("/files/etc/group/new_group/user[1]"),"nuser1")
-       assert_equal( aug.get("/files/etc/group/new_group/user[2]"),"nuser2" )
-       assert_equal( aug.get("/files/etc/group/new_group/user[3]"),"nuser3" )
-
-       aug.rm("/files/etc/group/disk/user")
-       aug.set("/files/etc/group/disk/user[last()+1]","testuser")
-       assert_equal( aug.get("/files/etc/group/disk/user"),"testuser")
-
-       aug.rm("/files/etc/group/disk/user")
-       aug.set("/files/etc/group/disk/user[last()+1]", nil)
-       assert_equal( aug.get("/files/etc/group/disk/user"), nil)
-    end
-
-    def test_setm
-        aug = aug_open
-
-        aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]","users", "testuser1")
-        assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser1")
-        assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser1")
-
-        aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]/users",nil, "testuser2")
-        assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser2")
-        assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser2")
-    end
-
-    def test_error
-        aug = aug_open
-
-        # Cause an error
-        aug.get("/files/etc/hosts/*")
-        err = aug.error
-        assert_equal(Augeas::EMMATCH, err[:code])
-        assert err[:message]
-        assert err[:details]
-        assert err[:minor].nil?
-    end
-
-    def test_span
-        aug = aug_open
-
-        span = aug.span("/files/etc/ssh/sshd_config/Protocol")
-        assert_equal({}, span)
-
-        aug.set("/augeas/span", "enable")
-        aug.rm("/files/etc")
-        aug.load
-
-        span = aug.span("/files/etc/ssh/sshd_config/Protocol")
-        assert_not_nil(span[:filename])
-        assert_equal(29..37, span[:label])
-        assert_equal(38..39, span[:value])
-        assert_equal(29..40, span[:span])
-    end
-
-    private
-    def aug_open(flags = Augeas::NONE)
-        if File::directory?(TST_ROOT)
-            FileUtils::rm_rf(TST_ROOT)
-        end
-        FileUtils::mkdir_p(TST_ROOT)
-        FileUtils::cp_r(SRC_ROOT, TST_ROOT)
-
-        Augeas::open(TST_ROOT, nil, flags)
-    end
+    Augeas::open(TST_ROOT, nil, flags)
+  end
 end

--- a/tests/tc_augeas_old.rb
+++ b/tests/tc_augeas_old.rb
@@ -45,6 +45,15 @@ class TestAugeasOld < Test::Unit::TestCase
         end
     end
 
+    def test_open_block
+        foo = nil
+        Augeas::open do |aug|
+            aug.set('/foo', 'bar')
+            foo = aug.get('/foo')
+        end
+        assert_equal(foo, 'bar')
+    end
+
     def test_close
         aug = Augeas::open("/tmp", nil, Augeas::SAVE_NEWFILE)
         assert_equal("newfile", aug.get("/augeas/save"))

--- a/tests/tc_augeas_old.rb
+++ b/tests/tc_augeas_old.rb
@@ -11,7 +11,7 @@ $:.unshift(File::join(TOPDIR, "ext", "augeas"))
 require 'augeas'
 require 'fileutils'
 
-class TestAugeas < Test::Unit::TestCase
+class TestAugeasOld < Test::Unit::TestCase
 
     SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
     TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"


### PR DESCRIPTION
I was annoyed at the fact that most augeas errors passed silently only returning an error code which meant having to check after each command if there actually was an error. I think that behaviour is very C-like and not very ruby like. Instead I think the user should be prompted immediately when an error happened and which kind of error it was.

This code does the following:
- raises ruby exceptions on error (these are the same as the ones in the C library, they have the same message, but their names were changed to be more suggestive (e.g. ECMDRUN -> CommandExecutionError)
- almost all commands are now declared in the ruby module and passed through a run_command private method which checks for errors and raises them (the corresponding methods from the C bindings file are now private)
- a lot of new unit tests have been added for all the new errors and a few for normal invocation of methods which lacked unit tests before

There are some issues remaining, mostly around the load and save commands which seem to have quite a different policy about errors (1. storing them in the augeas tree, 2. returning success when failing in case of load), but that should be a different issue.

Thanks!
